### PR TITLE
Reply-to sender

### DIFF
--- a/admin_email.php
+++ b/admin_email.php
@@ -55,6 +55,8 @@ if(has_capability('block/quickmail:myaddinstance', $context) || is_siteadmin($US
     $PAGE->navbar->add($blockname);
     $PAGE->navbar->add($header);
     $PAGE->set_heading($SITE->shortname.': '.$blockname);
+    $PAGE->set_pagetype(quickmail::PAGE_TYPE);
+    $PAGE->set_pagelayout('standard');
 
     if($type == 'log'){
         $log_message = $DB->get_record('block_quickmail_' . $type, array('id' => $typeid));

--- a/alternate.php
+++ b/alternate.php
@@ -53,6 +53,8 @@ $PAGE->navbar->add($heading);
 
 $PAGE->set_title($title);
 $PAGE->set_heading($title);
+$PAGE->set_pagetype(quickmail::PAGE_TYPE);
+$PAGE->set_pagelayout('standard');
 
 if (!method_exists('quickmail_alternate', $action)) {
     // Always fallback on view

--- a/backup/moodle2/restore_quickmail_stepslib.php
+++ b/backup/moodle2/restore_quickmail_stepslib.php
@@ -49,18 +49,18 @@ class restore_quickmail_log_structure_step extends restore_structure_step {
         if ($restore and isset($data->emaillogs['log'])) {
             global $DB;
 
-            $current = context_course::instance($this->get_courseid());
+            $current_context = context_course::instance($this->get_courseid());
 
             $params = array(
                 'backupid' => $this->get_restoreid(),
                 'itemname' => 'context',
-                'newitemid' => $context->id
+                'newitemid' => $current_context->id
             );
 
             $id = $DB->get_record('backup_ids_temp', $params)->itemid;
 
             foreach ($data->emaillogs['log'] as $log) {
-                $this->process_log($log, $id, $context);
+                $this->process_log($log, $id, $current_context);
             }
         }
 

--- a/config_qm.php
+++ b/config_qm.php
@@ -49,6 +49,7 @@ $PAGE->set_heading($blockname. ': '. $header);
 $PAGE->navbar->add($blockname);
 $PAGE->navbar->add($header);
 $PAGE->set_pagetype(quickmail::PAGE_TYPE);
+$PAGE->set_pagelayout('standard');
 
 $changed = false;
 

--- a/email.php
+++ b/email.php
@@ -156,7 +156,7 @@ if (empty($users)) {
     echo $OUTPUT->notification(quickmail::_s('no_usergroups'), 'notifyproblem');
     
     echo html_writer::start_tag('div', array('class' => 'no-overflow'));
-    echo html_writer::link(new moodle_url('/course/view.php', ['id' => $courseid]), 'Back to previous page', null);
+    echo html_writer::link(new moodle_url('/course/view.php', ['id' => $courseid]), get_string('back_to_previous', 'block_quickmail'), null);
     echo html_writer::end_tag('div');
     
     echo $OUTPUT->footer();

--- a/email.php
+++ b/email.php
@@ -160,240 +160,242 @@ if (empty($users)) {
     echo html_writer::end_tag('div');
     
     echo $OUTPUT->footer();
-}
-
-// we are presenting the form with values populated from either the log or drafts table in the db
-if (!empty($type)) {
-    
-    $email = $DB->get_record('block_quickmail_' . $type, array('id' => $typeid));
-    //$emailmailto = array();
-    if ($type == 'log') {
-        $attributes = array ('id' => "{$typeid}_id_message_editor");
-    }
-
-    if ($messageIDresend == 1) {
-        list($email->mailto, $email->additional_emails) = quickmail::clean($email->failuserids);
-    }
 } else {
-    $email = new stdClass;
-    $email->id = null;
-}
-$email->messageformat =  editors_get_preferred_format();
-$default_sigid = $DB->get_field('block_quickmail_signatures', 'id', array(
-    'userid' => $USER->id, 'default_flag' => 1
-));
-$email->sigid = $default_sigid ? $default_sigid : -1;
 
-// Some setters for the form
-$email->type = $type;
-$email->typeid = $typeid;
-
-$editor_options = array(
-    'trusttext' => false,
-    'subdirs' => 1,
-    'maxfiles' => EDITOR_UNLIMITED_FILES,
-    'accepted_types' => '*',
-    'context' => $context
-);
-
-$email = file_prepare_standard_editor(
-    $email, 'message', $editor_options, $context, 'block_quickmail', $type, $email->id
-);
-
-$selected = array();
-if (!empty($email->mailto)) {
-    foreach (explode(',', $email->mailto) as $id) {
-        $selected[$id] = (object) array('id'=>$id,'firstname'=>null,'lastname'=>null,'email'=>$id,'mailformat'=>'1','suspended'=>'0','maildisplay'=>'2','status'=>'0'); 
-        if(is_numeric($selected[$id]->id)) {
-            $selected[$id] = $users[$id];
-        } 
-        unset($users[$id]);
-    }
-}
-
-
-$form = new email_form(null, array(
-    'editor_options' => $editor_options,
-    'selected' => $selected,
-    'users' => $users,
-    'roles' => $roles,
-    'groups' => $groups,
-    'users_to_roles' => $users_to_roles,
-    'users_to_groups' => $users_to_groups,
-    'sigs' => array_map(function($sig) { return $sig->title; }, $sigs),
-    'alternates' => $alternates,
-    'attributes' => $attributes
-));
-
-$warnings = array();
-//
-if ($form->is_cancelled()) {
-    redirect(new moodle_url('/course/view.php?id=' . $courseid));
-    // DWE we should check if we have selected users or emails around here. 
-} else if ($data = $form->get_data()) {
-    if (empty($data->subject)) {
-        $warnings[] = get_string('no_subject', 'block_quickmail');
-    }
-    if (empty($data->mailto) && empty($data->additional_emails)) {
-        $warnings[] = get_string('no_users', 'block_quickmail');
-    }
-    if (empty($warnings)) {
-        // Submitted data //////////////////////////////////////////////////////
-        $data->time = time();
-        $data->format = $data->message_editor['format'];
-        $data->message = $data->message_editor['text'];
-        $data->attachment = quickmail::attachment_names($data->attachments);
-        $data->messageWithSigAndAttach = "";
-        // Store data; id is needed for file storage ///////////////////////////
-        if (isset($data->send)) {
-            $data->id = $DB->insert_record('block_quickmail_log', $data);
-            $table = 'log';
-        } else if (isset($data->draft)) {
-            $table = 'drafts';
-
-            if (!empty($typeid) and $type == 'drafts') {
-                $data->id = $typeid;
-                $DB->update_record('block_quickmail_drafts', $data);
-            } else {
-                $data->id = $DB->insert_record('block_quickmail_drafts', $data);
-            }
-        }
-        $data = file_postupdate_standard_editor(
-            $data, 'message', $editor_options, $context, 'block_quickmail', $table, $data->id
-        );
-        $DB->update_record('block_quickmail_' . $table, $data);
-
-        $prepender = $config['prepend_class'];
-        if (!empty($prepender) and !empty($course->$prepender)) {
-            $subject = "[{$course->$prepender}] $data->subject";
-        } else {
-            $subject = $data->subject;
-        }
-
-        // An instance id is needed before storing the file repository /////////
-        file_save_draft_area_files(
-                $data->attachments, $context->id, 'block_quickmail', 'attachment_' . $table, $data->id, $editor_options
-        );
-
-        // Send emails /////////////////////////////////////////////////////////
-        if (isset($data->send)) {
-            if ($type == 'drafts') {
-                quickmail::draft_cleanup($context->id, $typeid);
-            }
-            // deal with possible signature, will be appended to message in a little bit.
-            if (!empty($sigs) and $data->sigid > -1) {
-                $sig = $sigs[$data->sigid];
-                $signaturetext = file_rewrite_pluginfile_urls($sig->signature, 'pluginfile.php', $context->id, 'block_quickmail', 'signature', $sig->id, $editor_options);
-            }
-
-            // Prepare html content of message /////////////////////////////////
-            $data->message = file_rewrite_pluginfile_urls($data->message, 'pluginfile.php', $context->id, 'block_quickmail', $table, $data->id, $editor_options);
-
-            if(empty($signaturetext)){
-                $data->messageWithSigAndAttach = $data->message;
-            }
-            else{
-                if($data->format == 0 || $data->format == 2 ){
-                    $data->messageWithSigAndAttach = $data->message . "\n\n" .$signaturetext;
-                }else{
-                    $data->messageWithSigAndAttach = $data->message . "<br /> <br /> <p></p>" .$signaturetext;
-                }
-            }
-            // Append links to attachments, if any /////////////////////////////
-                $data->messageWithSigAndAttach .= quickmail::process_attachments(
-                    $context, $data, $table, $data->id
-                );
-
-            // Same user, alternate email //////////////////////////////////////
-            if (!empty($data->alternateid)) {
-                $user = clone($USER);
-                $user->email = $alternates[$data->alternateid];
-            } else {
-                $user = $USER;
-            }
-            $data->failuserids = array();
-            // DWE -> Begin hopefully new way of dealing with messagetext and messagehtml
-
-            // TEXT
-            // This is where we'll need to factor in the preferences of the receiver.
-            $messagetext = format_text_email($data->messageWithSigAndAttach, $data->format);
-
-            // HTML
-            $options = array('filter' => false);
-            $messagehtml = format_text($data->messageWithSigAndAttach, $data->format, $options);
-
-            if(!empty($data->mailto)) {
-
-                foreach (explode(',', $data->mailto) as $userid) {
-                    // Email gets sent here
-                    if ($everyone[$userid]->value) { $everyone[$userid]->email = $everyone[$userid]->value; }
-                    $success = email_to_user($everyone[$userid], $user, $subject,$messagetext, $messagehtml);
-                    if (!$success) {
-                        $warnings[] = get_string("no_email", 'block_quickmail', $everyone[$userid]);
-                        $data->failuserids[] = $userid;
-                    }
-                }
-            }
-
-        if(!empty($data->additional_emails)){
-            $additional_email_array = preg_split('/[,;]/', $data->additional_emails);
-                $i = 0;
-                foreach ($additional_email_array as $additional_email) {
-                    $additional_email = trim($additional_email); 
-                    $fakeuser = new stdClass();
-                    $fakeuser->id = 99999900 + $i;
-                    $fakeuser->email = $additional_email;
-                    // TODO make this into a menu option
-                    $fakeuser->mailformat = 1;
-                    $additional_email_success = email_to_user($fakeuser, $user, $subject, $messagetext, $messagehtml);
-                    if (!$additional_email_success) {
-                        $data->failuserids[] = $additional_email;
-                        // will need to notify that an email is incorrect
-                        $warnings[] = get_string("no_email_address", 'block_quickmail', $fakeuser->email);
-                    }
-                    $i++;
-                }
-        }
-
-            $data->failuserids = implode(',', $data->failuserids);
-            $DB->update_record('block_quickmail_log', $data);
-
-            if ($data->receipt) {
-                email_to_user($USER, $user, $subject, $messagetext, $messagehtml);
-            }
-        }
-    }
-    $email = $data;
-}
-
-if (empty($email->attachments)) {
+    // we are presenting the form with values populated from either the log or drafts table in the db
     if (!empty($type)) {
-        $attachid = file_get_submitted_draft_itemid('attachment');
-        file_prepare_draft_area(
-            $attachid, $context->id, 'block_quickmail', 'attachment_' . $type, $typeid
-        );
-        $email->attachments = $attachid;
+        
+        $email = $DB->get_record('block_quickmail_' . $type, array('id' => $typeid));
+        //$emailmailto = array();
+        if ($type == 'log') {
+            $attributes = array ('id' => "{$typeid}_id_message_editor");
+        }
+
+        if ($messageIDresend == 1) {
+            list($email->mailto, $email->additional_emails) = quickmail::clean($email->failuserids);
+        }
+    } else {
+        $email = new stdClass;
+        $email->id = null;
     }
-}
 
-$form->set_data($email);
-if (empty($warnings)) {
-    if (isset($email->send)) {
-        redirect(new moodle_url('/blocks/quickmail/emaillog.php', array('courseid' => $course->id)));
-    } else if (isset($email->draft)) {
-        $warnings['success'] = get_string("changessaved");
+    $email->messageformat =  editors_get_preferred_format();
+    $default_sigid = $DB->get_field('block_quickmail_signatures', 'id', array(
+        'userid' => $USER->id, 'default_flag' => 1
+    ));
+    $email->sigid = $default_sigid ? $default_sigid : -1;
+
+    // Some setters for the form
+    $email->type = $type;
+    $email->typeid = $typeid;
+
+    $editor_options = array(
+        'trusttext' => false,
+        'subdirs' => 1,
+        'maxfiles' => EDITOR_UNLIMITED_FILES,
+        'accepted_types' => '*',
+        'context' => $context
+    );
+
+    $email = file_prepare_standard_editor(
+        $email, 'message', $editor_options, $context, 'block_quickmail', $type, $email->id
+    );
+
+    $selected = array();
+    if (!empty($email->mailto)) {
+        foreach (explode(',', $email->mailto) as $id) {
+            $selected[$id] = (object) array('id'=>$id,'firstname'=>null,'lastname'=>null,'email'=>$id,'mailformat'=>'1','suspended'=>'0','maildisplay'=>'2','status'=>'0'); 
+            if(is_numeric($selected[$id]->id)) {
+                $selected[$id] = $users[$id];
+            } 
+            unset($users[$id]);
+        }
     }
+
+
+    $form = new email_form(null, array(
+        'editor_options' => $editor_options,
+        'selected' => $selected,
+        'users' => $users,
+        'roles' => $roles,
+        'groups' => $groups,
+        'users_to_roles' => $users_to_roles,
+        'users_to_groups' => $users_to_groups,
+        'sigs' => array_map(function($sig) { return $sig->title; }, $sigs),
+        'alternates' => $alternates,
+        'attributes' => $attributes
+    ));
+
+    $warnings = array();
+    //
+    if ($form->is_cancelled()) {
+        redirect(new moodle_url('/course/view.php?id=' . $courseid));
+        // DWE we should check if we have selected users or emails around here. 
+    } else if ($data = $form->get_data()) {
+        if (empty($data->subject)) {
+            $warnings[] = get_string('no_subject', 'block_quickmail');
+        }
+        if (empty($data->mailto) && empty($data->additional_emails)) {
+            $warnings[] = get_string('no_users', 'block_quickmail');
+        }
+        if (empty($warnings)) {
+            // Submitted data //////////////////////////////////////////////////////
+            $data->time = time();
+            $data->format = $data->message_editor['format'];
+            $data->message = $data->message_editor['text'];
+            $data->attachment = quickmail::attachment_names($data->attachments);
+            $data->messageWithSigAndAttach = "";
+            // Store data; id is needed for file storage ///////////////////////////
+            if (isset($data->send)) {
+                $data->id = $DB->insert_record('block_quickmail_log', $data);
+                $table = 'log';
+            } else if (isset($data->draft)) {
+                $table = 'drafts';
+
+                if (!empty($typeid) and $type == 'drafts') {
+                    $data->id = $typeid;
+                    $DB->update_record('block_quickmail_drafts', $data);
+                } else {
+                    $data->id = $DB->insert_record('block_quickmail_drafts', $data);
+                }
+            }
+            $data = file_postupdate_standard_editor(
+                $data, 'message', $editor_options, $context, 'block_quickmail', $table, $data->id
+            );
+            $DB->update_record('block_quickmail_' . $table, $data);
+
+            $prepender = $config['prepend_class'];
+            if (!empty($prepender) and !empty($course->$prepender)) {
+                $subject = "[{$course->$prepender}] $data->subject";
+            } else {
+                $subject = $data->subject;
+            }
+
+            // An instance id is needed before storing the file repository /////////
+            file_save_draft_area_files(
+                    $data->attachments, $context->id, 'block_quickmail', 'attachment_' . $table, $data->id, $editor_options
+            );
+
+            // Send emails /////////////////////////////////////////////////////////
+            if (isset($data->send)) {
+                if ($type == 'drafts') {
+                    quickmail::draft_cleanup($context->id, $typeid);
+                }
+                // deal with possible signature, will be appended to message in a little bit.
+                if (!empty($sigs) and $data->sigid > -1) {
+                    $sig = $sigs[$data->sigid];
+                    $signaturetext = file_rewrite_pluginfile_urls($sig->signature, 'pluginfile.php', $context->id, 'block_quickmail', 'signature', $sig->id, $editor_options);
+                }
+
+                // Prepare html content of message /////////////////////////////////
+                $data->message = file_rewrite_pluginfile_urls($data->message, 'pluginfile.php', $context->id, 'block_quickmail', $table, $data->id, $editor_options);
+
+                if(empty($signaturetext)){
+                    $data->messageWithSigAndAttach = $data->message;
+                }
+                else{
+                    if($data->format == 0 || $data->format == 2 ){
+                        $data->messageWithSigAndAttach = $data->message . "\n\n" .$signaturetext;
+                    }else{
+                        $data->messageWithSigAndAttach = $data->message . "<br /> <br /> <p></p>" .$signaturetext;
+                    }
+                }
+                // Append links to attachments, if any /////////////////////////////
+                    $data->messageWithSigAndAttach .= quickmail::process_attachments(
+                        $context, $data, $table, $data->id
+                    );
+
+                // Same user, alternate email //////////////////////////////////////
+                if (!empty($data->alternateid)) {
+                    $user = clone($USER);
+                    $user->email = $alternates[$data->alternateid];
+                } else {
+                    $user = $USER;
+                }
+                $data->failuserids = array();
+                // DWE -> Begin hopefully new way of dealing with messagetext and messagehtml
+
+                // TEXT
+                // This is where we'll need to factor in the preferences of the receiver.
+                $messagetext = format_text_email($data->messageWithSigAndAttach, $data->format);
+
+                // HTML
+                $options = array('filter' => false);
+                $messagehtml = format_text($data->messageWithSigAndAttach, $data->format, $options);
+
+                if(!empty($data->mailto)) {
+
+                    foreach (explode(',', $data->mailto) as $userid) {
+                        // Email gets sent here
+                        if ($everyone[$userid]->value) { $everyone[$userid]->email = $everyone[$userid]->value; }
+                        $success = email_to_user($everyone[$userid], $user, $subject,$messagetext, $messagehtml);
+                        if (!$success) {
+                            $warnings[] = get_string("no_email", 'block_quickmail', $everyone[$userid]);
+                            $data->failuserids[] = $userid;
+                        }
+                    }
+                }
+
+            if(!empty($data->additional_emails)){
+                $additional_email_array = preg_split('/[,;]/', $data->additional_emails);
+                    $i = 0;
+                    foreach ($additional_email_array as $additional_email) {
+                        $additional_email = trim($additional_email); 
+                        $fakeuser = new stdClass();
+                        $fakeuser->id = 99999900 + $i;
+                        $fakeuser->email = $additional_email;
+                        // TODO make this into a menu option
+                        $fakeuser->mailformat = 1;
+                        $additional_email_success = email_to_user($fakeuser, $user, $subject, $messagetext, $messagehtml);
+                        if (!$additional_email_success) {
+                            $data->failuserids[] = $additional_email;
+                            // will need to notify that an email is incorrect
+                            $warnings[] = get_string("no_email_address", 'block_quickmail', $fakeuser->email);
+                        }
+                        $i++;
+                    }
+            }
+
+                $data->failuserids = implode(',', $data->failuserids);
+                $DB->update_record('block_quickmail_log', $data);
+
+                if ($data->receipt) {
+                    email_to_user($USER, $user, $subject, $messagetext, $messagehtml);
+                }
+            }
+        }
+        $email = $data;
+    }
+
+    if (empty($email->attachments)) {
+        if (!empty($type)) {
+            $attachid = file_get_submitted_draft_itemid('attachment');
+            file_prepare_draft_area(
+                $attachid, $context->id, 'block_quickmail', 'attachment_' . $type, $typeid
+            );
+            $email->attachments = $attachid;
+        }
+    }
+
+    $form->set_data($email);
+    if (empty($warnings)) {
+        if (isset($email->send)) {
+            redirect(new moodle_url('/blocks/quickmail/emaillog.php', array('courseid' => $course->id)));
+        } else if (isset($email->draft)) {
+            $warnings['success'] = get_string("changessaved");
+        }
+    }
+
+    echo $OUTPUT->header();
+    echo $OUTPUT->heading($blockname);
+
+    foreach ($warnings as $type => $warning) {
+        $class = ($type === 'success') ? 'notifysuccess' : 'notifyproblem';
+        echo $OUTPUT->notification($warning, $class);
+    }
+
+    echo html_writer::start_tag('div', array('class' => 'no-overflow'));
+    $form->display();
+    echo html_writer::end_tag('div');
+    echo $OUTPUT->footer();
 }
-
-echo $OUTPUT->header();
-echo $OUTPUT->heading($blockname);
-
-foreach ($warnings as $type => $warning) {
-    $class = ($type === 'success') ? 'notifysuccess' : 'notifyproblem';
-    echo $OUTPUT->notification($warning, $class);
-}
-
-echo html_writer::start_tag('div', array('class' => 'no-overflow'));
-$form->display();
-echo html_writer::end_tag('div');
-echo $OUTPUT->footer();

--- a/email.php
+++ b/email.php
@@ -154,17 +154,17 @@ if (empty($users)) {
     echo $OUTPUT->header();
     echo $OUTPUT->heading($blockname);
     echo $OUTPUT->notification(quickmail::_s('no_usergroups'), 'notifyproblem');
-    
+
     echo html_writer::start_tag('div', array('class' => 'no-overflow'));
     echo html_writer::link(new moodle_url('/course/view.php', ['id' => $courseid]), get_string('back_to_previous', 'block_quickmail'), null);
     echo html_writer::end_tag('div');
-    
+
     echo $OUTPUT->footer();
 } else {
 
     // we are presenting the form with values populated from either the log or drafts table in the db
     if (!empty($type)) {
-        
+
         $email = $DB->get_record('block_quickmail_' . $type, array('id' => $typeid));
         //$emailmailto = array();
         if ($type == 'log') {
@@ -204,10 +204,10 @@ if (empty($users)) {
     $selected = array();
     if (!empty($email->mailto)) {
         foreach (explode(',', $email->mailto) as $id) {
-            $selected[$id] = (object) array('id'=>$id,'firstname'=>null,'lastname'=>null,'email'=>$id,'mailformat'=>'1','suspended'=>'0','maildisplay'=>'2','status'=>'0'); 
+            $selected[$id] = (object) array('id'=>$id,'firstname'=>null,'lastname'=>null,'email'=>$id,'mailformat'=>'1','suspended'=>'0','maildisplay'=>'2','status'=>'0');
             if(is_numeric($selected[$id]->id)) {
                 $selected[$id] = $users[$id];
-            } 
+            }
             unset($users[$id]);
         }
     }
@@ -230,7 +230,7 @@ if (empty($users)) {
     //
     if ($form->is_cancelled()) {
         redirect(new moodle_url('/course/view.php?id=' . $courseid));
-        // DWE we should check if we have selected users or emails around here. 
+        // DWE we should check if we have selected users or emails around here.
     } else if ($data = $form->get_data()) {
         if (empty($data->subject)) {
             $warnings[] = get_string('no_subject', 'block_quickmail');
@@ -328,7 +328,7 @@ if (empty($users)) {
                     foreach (explode(',', $data->mailto) as $userid) {
                         // Email gets sent here
                         if ($everyone[$userid]->value) { $everyone[$userid]->email = $everyone[$userid]->value; }
-                        $success = email_to_user($everyone[$userid], $user, $subject,$messagetext, $messagehtml);
+                        $success = email_to_user($everyone[$userid], $user, $subject,$messagetext, $messagehtml, '', '', false, $user->email);
                         if (!$success) {
                             $warnings[] = get_string("no_email", 'block_quickmail', $everyone[$userid]);
                             $data->failuserids[] = $userid;
@@ -340,7 +340,7 @@ if (empty($users)) {
                 $additional_email_array = preg_split('/[,;]/', $data->additional_emails);
                     $i = 0;
                     foreach ($additional_email_array as $additional_email) {
-                        $additional_email = trim($additional_email); 
+                        $additional_email = trim($additional_email);
                         $fakeuser = new stdClass();
                         $fakeuser->id = 99999900 + $i;
                         $fakeuser->email = $additional_email;
@@ -360,7 +360,7 @@ if (empty($users)) {
                 $DB->update_record('block_quickmail_log', $data);
 
                 if ($data->receipt) {
-                    email_to_user($USER, $user, $subject, $messagetext, $messagehtml);
+                    email_to_user($USER, $user, $subject, $messagetext, $messagehtml, '', '', false, $user->email);
                 }
             }
         }

--- a/email_form.php
+++ b/email_form.php
@@ -150,12 +150,12 @@ class email_form extends moodleform {
         $select_filter = new html_table_cell();
         $select_filter->text = html_writer::tag('select',
             array_reduce($this->_customdata['selected'], array($this, 'reduce_users'), ''),
-            array('id' => 'mail_users', 'multiple' => 'multiple', 'size' => 30));
+            array('id' => 'mail_users', 'class' => 'select custom-select menu', 'multiple' => 'multiple', 'size' => 30));
 
         $embed = function ($text, $id) {
             return html_writer::tag('p',
                 html_writer::empty_tag('input', array(
-                    'value' => $text, 'type' => 'button', 'id' => $id
+                    'value' => $text, 'type' => 'button', 'class' => 'btn btn-secondary' , 'id' => $id
                 ))
             );
         };

--- a/emaillog.php
+++ b/emaillog.php
@@ -86,6 +86,7 @@ $PAGE->set_title($blockname . ': ' . $header);
 $PAGE->set_heading($blockname . ': ' . $header);
 $PAGE->set_url('/blocks/quickmail/emaillog.php', array('courseid' => $courseid));
 $PAGE->set_pagetype(quickmail::PAGE_TYPE);
+$PAGE->set_pagelayout('standard');
 
 $dbtable = 'block_quickmail_' . $type;
 

--- a/js/selection.js
+++ b/js/selection.js
@@ -50,7 +50,7 @@
     $("#add_all").click(move(potentials, mailed, '*'));
     $("#remove_button").click(move(mailed, potentials, ':selected'));
     $("#remove_all").click(move(mailed, potentials, '*'));
-    return $("#mform1").submit(function() {
+    return $(".mform").submit(function() {
       var ids, mapper;
       mapper = function(index, elem) {
         return $(elem).val().split(' ')[0];

--- a/lang/en/block_quickmail.php
+++ b/lang/en/block_quickmail.php
@@ -61,6 +61,7 @@ $string['select_groups'] = 'Select Sections ...';
 $string['moodle_attachments'] = 'Moodle Attachments ({$a})';
 $string['download_all'] = 'Download All';
 $string['qm_contents'] = 'Download File Contents';
+$string['back_to_previous'] = 'Back to previous page';
 
 // Config form strings
 $string['allowstudents'] = 'Allow students to use Quickmail';

--- a/lib.php
+++ b/lib.php
@@ -33,7 +33,7 @@ abstract class quickmail {
     }
 
     static function format_time($time) {
-        return userdate($time, '%A, %d %B %Y, %I:%M %P');
+        return userdate($time, '%m-%d-%Y, %I:%M %p');
     }
 
     static function cleanup($table, $contextid, $itemid) {

--- a/signature.php
+++ b/signature.php
@@ -65,6 +65,7 @@ $PAGE->navbar->add($header);
 $PAGE->set_title($title);
 $PAGE->set_heading($title);
 $PAGE->set_pagetype(quickmail::PAGE_TYPE);
+$PAGE->set_pagelayout('standard');
 
 $params = array('userid' => $USER->id);
 $dbsigs = $DB->get_records('block_quickmail_signatures', $params);

--- a/styles.css
+++ b/styles.css
@@ -55,7 +55,6 @@
    float:none;
    position:center;
    overflow:hidden;
-   min-width:900px;
    width:100%;
    text-align:left;
    margin:auto;

--- a/styles.css
+++ b/styles.css
@@ -1,16 +1,18 @@
 #page-block-quickmail-admin_email div.region-content table.generaltable {
-   margin: 0 auto 30px auto;
-   width: 70%;
+    margin: 0 auto 30px auto;
+    width: 70%;
 }
 
-#page-block-quickmail div.region-content select.select, #page-block-quickmail div.region-content table.generaltable, #page-block-quickmail div.region-content div.generalbox {
-   margin-left: 20px;
-   margin-right: 20px;
+#page-block-quickmail div.region-content select.select,
+#page-block-quickmail div.region-content table.generaltable,
+#page-block-quickmail div.region-content div.generalbox {
+    margin-left: 20px;
+    margin-right: 20px;
 }
 
 #page-block-quickmail select[multiple] {
-   min-width: 250px;
-   max-width: 250px;
+    min-width: 250px;
+    max-width: 250px;
 }
 
 #page-block-quickmail .mform {
@@ -20,7 +22,8 @@
     background-color: inherit;
 }
 
-#page-block-quickmail .emailtable .r1 .c0, .emailtable .r1 .c2 {
+#page-block-quickmail .emailtable .r1 .c0,
+.emailtable .r1 .c2 {
     width: 275px;
 }
 
@@ -50,7 +53,7 @@
     text-align: right;
 }
 
-#page-block-quickmail .mform fieldset.hidden>div {
+#page-block-quickmail .mform fieldset.hidden > div {
    clear:both;
    float:none;
    position:center;
@@ -60,11 +63,14 @@
    margin:auto;
 }
 
-#page-block-quickmail .mform #add_button, #remove_button, #add_all, #remove_all {
-   width: 100px;
-   height: 25px;
+#page-block-quickmail .mform #add_button,
+#remove_button,
+#add_all,
+#remove_all {
+    width: 100px;
+    height: 25px;
 }
 
 #page-block-quickmail .mform input#id_subject {
-  width: 75%;
+    width: 75%;
 }

--- a/styles.css
+++ b/styles.css
@@ -60,11 +60,6 @@
    margin:auto;
 }
 
-#page-block-quickmail .mform #add_button, #remove_button, #add_all, #remove_all {
-   width: 100px;
-   height: 25px;
-}
-
 #page-block-quickmail .mform input#id_subject {
   width: 75%;
 }

--- a/version.php
+++ b/version.php
@@ -21,8 +21,8 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-$plugin->version = 2017122000;
+$plugin->version = 2017122001;
 $plugin->requires = 2013051400;
-$plugin->release = "v1.7.5";
+$plugin->release = "v1.7.6";
 $plugin->maturity = MATURITY_STABLE; 
 $plugin->component = 'block_quickmail';

--- a/version.php
+++ b/version.php
@@ -21,8 +21,8 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-$plugin->version = 2017110300;
+$plugin->version = 2017110700;
 $plugin->requires = 2013051400;
-$plugin->release = "v1.7.3";
+$plugin->release = "v1.7.4";
 $plugin->maturity = MATURITY_STABLE; 
 $plugin->component = 'block_quickmail';

--- a/version.php
+++ b/version.php
@@ -21,8 +21,8 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-$plugin->version = 2017110700;
+$plugin->version = 2017122000;
 $plugin->requires = 2013051400;
-$plugin->release = "v1.7.4";
+$plugin->release = "v1.7.5";
 $plugin->maturity = MATURITY_STABLE; 
 $plugin->component = 'block_quickmail';

--- a/version.php
+++ b/version.php
@@ -21,8 +21,8 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-$plugin->version = 2017080300;
+$plugin->version = 2017103000;
 $plugin->requires = 2013051400;
-$plugin->release = "v1.7.1";
+$plugin->release = "v1.7.2";
 $plugin->maturity = MATURITY_STABLE; 
 $plugin->component = 'block_quickmail';

--- a/version.php
+++ b/version.php
@@ -21,8 +21,8 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-$plugin->version = 2017103000;
+$plugin->version = 2017110300;
 $plugin->requires = 2013051400;
-$plugin->release = "v1.7.2";
+$plugin->release = "v1.7.3";
 $plugin->maturity = MATURITY_STABLE; 
 $plugin->component = 'block_quickmail';


### PR DESCRIPTION
refs #1 

this sets the sending user's email address as `reply-to` mail header explicitly, except for when the mail is sent from an "alternative email".

note that this does not implement an admin configuration for enabling/disabling the default behaviour of this block, as mentioned in the corresponding ticket. 