### PR TITLE
use default nvm in the CI pipeline again.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,9 +60,7 @@ jobs:
           echo $(cd ci/bin; pwd) >> $GITHUB_PATH
           echo $(cd ci/vendor/bin; pwd) >> $GITHUB_PATH
           sudo locale-gen en_AU.UTF-8
-          #echo "NVM_DIR=$HOME/.nvm" >> $GITHUB_ENV
-          # Install nvm v0.39.7 (Temporary workaround for https://github.com/moodlehq/moodle-plugin-ci/issues/309).
-          curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+          echo "NVM_DIR=$HOME/.nvm" >> $GITHUB_ENV
 
       - name: Install moodle-plugin-ci
         run: |


### PR DESCRIPTION
the upstream regression that required manual installation and pinning of a specific NVM version has been fixed with moodle-plugin-ci release v3.4.14.

for reference, please see
https://github.com/moodlehq/moodle-plugin-ci/releases/tag/3.4.14.